### PR TITLE
Extend generic parent with type arguments

### DIFF
--- a/src/test/php/lang/ast/syntax/php/unittest/GenericsTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/GenericsTest.class.php
@@ -64,6 +64,18 @@ class GenericsTest extends EmittingTest {
   }
 
   #[Test]
+  public function extends_generic_parent_with_type_argument() {
+    $i= $this->type('abstract class <T><E> {
+      public function defaultValue(): E { return $E->default; }
+    }');
+    $t= $this->type('class <T> extends '.$i->getName().'<string> { }');
+
+    $c= Primitive::$STRING;
+    Assert::equals([$c], $t->getParentclass()->genericArguments());
+    Assert::equals('', $t->newInstance()->defaultValue());
+  }
+
+  #[Test]
   public function new_creates_generic_types() {
     $r= $this->run('class <T><E> {
       public function run() {


### PR DESCRIPTION
## Use case

```php
use test\Test;
use com\example\api\Suggestions;

class ApiTest<T> {
  protected function newFixture(): T { return $T->newInstance(new TestingRepository()); }
}

class SuggestionTest extends ApiTest<Suggestions> {

  #[Test]
  public function can_create() {
    $this->newFixture();
  }
}
```