### PR TITLE
Add support for casts

### DIFF
--- a/src/main/php/lang/ast/syntax/php/IsGenericDeclaration.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsGenericDeclaration.class.php
@@ -1,0 +1,20 @@
+<?php namespace lang\ast\syntax\php;
+
+use lang\ast\Type;
+
+class IsGenericDeclaration extends Type {
+  private $type;
+
+  public function __construct($type) {
+    $this->type= $type;
+  }
+
+  /** @return string */
+  public function name() { return $this->type->base->name(); }
+
+  /** @return string */
+  public function literal() { return $this->type->base->literal(); }
+
+  /** @return parent[] */
+  public function components() { return $this->type->components; }
+}

--- a/src/test/php/lang/ast/syntax/php/unittest/CastingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/CastingTest.class.php
@@ -1,0 +1,81 @@
+<?php namespace lang\ast\syntax\php\unittest;
+
+use lang\ast\unittest\emit\EmittingTest;
+use lang\reflect\TargetInvocationException;
+use lang\{ArrayType, Primitive};
+use test\{Assert, Expect, Test, Values};
+
+class CastingTest extends EmittingTest {
+
+  /**
+   * Invokes static fixture method with the given arguments. Unwraps
+   * any exception thrown from `TargetInvocationException`.
+   *
+   * @param  lang.XPClass $type
+   * @param  var[] $arguments
+   * @return var
+   */
+  private function invokeFixture($type, $arguments= []) {
+    try {
+      return $type->getMethod('fixture')->invoke(null, $arguments);
+    } catch (TargetInvocationException $e) {
+      throw $e->getCause();
+    }
+  }
+
+  #[Test, Values([1, null, [[]]])]
+  public function regular_cast($value) {
+    $t= $this->type('class %T<V> {
+      public static function fixture($arg) {
+        return (array)$arg;
+      }
+    }');
+
+    Assert::equals(
+      (array)$value,
+      $this->invokeFixture($t->newGenericType([Primitive::$STRING]), [$value])
+    );
+  }
+
+  #[Test, Values([1, '', 'Test'])]
+  public function generic_cast($value) {
+    $t= $this->type('class %T<V> {
+      public static function fixture($arg) {
+        return (V)$arg;
+      }
+    }');
+
+    Assert::equals(
+      Primitive::$STRING->cast($value),
+      $this->invokeFixture($t->newGenericType([Primitive::$STRING]), [$value])
+    );
+  }
+
+  #[Test, Values([[[]], [[1, 2, 3]]])]
+  public function generic_array_cast($value) {
+    $t= $this->type('class %T<V> {
+      public static function fixture($arg) {
+        return (array<V>)$arg;
+      }
+    }');
+
+    Assert::equals(
+      (new ArrayType(Primitive::$STRING))->cast($value),
+      $this->invokeFixture($t->newGenericType([Primitive::$STRING]), [$value])
+    );
+  }
+
+  #[Test, Values([1, null, '', 'Test'])]
+  public function generic_nullable_cast($value) {
+    $t= $this->type('class %T<V> {
+      public static function fixture($arg) {
+        return (?V)$arg;
+      }
+    }');
+
+    Assert::equals(
+      Primitive::$STRING->cast($value),
+      $this->invokeFixture($t->newGenericType([Primitive::$STRING]), [$value])
+    );
+  }
+}

--- a/src/test/php/lang/ast/syntax/php/unittest/CastingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/CastingTest.class.php
@@ -78,4 +78,22 @@ class CastingTest extends EmittingTest {
       $this->invokeFixture($t->newGenericType([Primitive::$STRING]), [$value])
     );
   }
+
+  #[Test]
+  public function casting_used_for_coercion() {
+    $t= $this->type('class %T<T> {
+      private $begin, $end;
+
+      public function __construct($range) {
+        [$this->begin, $this->end]= (array<T>)$range;
+      }
+
+      public function begin(): T { return $this->begin; }
+
+      public function end(): T { return $this->end; }
+    }');
+
+    $range= $t->newGenericType([Primitive::$INT])->newInstance(['1', '10']);
+    Assert::equals([1, 10], [$range->begin(), $range->end()]);
+  }
 }


### PR DESCRIPTION
This pull request adds casting using generic components. The following example shows how this can be used for type coercion, where a parameter hint would raise an exception.

```php
class Range<T> {
  private $begin, $end;

  public function __construct($range) {
    [$this->begin, $this->end]= (array<T>)$range;
  }

  public function begin(): T { return $this->begin; }

  public function end(): T { return $this->end; }
}

$range= new Range<int>(['1', '10']);
$range->begin(); // int(1)
$range->end();   // int(10)
```