### PR TITLE
Add support for components type literals

### DIFF
--- a/src/main/php/lang/ast/syntax/php/Generics.class.php
+++ b/src/main/php/lang/ast/syntax/php/Generics.class.php
@@ -8,7 +8,8 @@ use lang\ast\nodes\{
   InvokeExpression,
   Literal,
   ScopeExpression,
-  TernaryExpression
+  TernaryExpression,
+  Variable
 };
 use lang\ast\syntax\Extension;
 use lang\ast\types\{IsArray, IsFunction, IsGeneric, IsMap, IsUnion, IsNullable, IsValue};
@@ -233,6 +234,18 @@ class Generics implements Extension {
           $node->arguments
         );
       }
+
+      // Rewrite `new T(...)` -> `$T->newInstance(...)` if T is a component
+      if (
+        $node->type instanceof IsValue &&
+        $generic= self::generic($node->type, $codegen->scope[0]->type->name->components())
+      ) {
+        return new InvokeExpression(
+          new InstanceExpression(new Variable($generic), new Literal('newInstance')),
+          $node->arguments
+        );
+      }
+
       return $node;
     });
 

--- a/src/main/php/lang/ast/syntax/php/Generics.class.php
+++ b/src/main/php/lang/ast/syntax/php/Generics.class.php
@@ -249,6 +249,19 @@ class Generics implements Extension {
       return $node;
     });
 
+    $emitter->transform('instanceof', function($codegen, $node) {
+
+      // Rewrite `... instanceof T` -> `$T->isInstance(...)` if T is a component
+      if ($generic= self::generic(new IsValue($node->type), $codegen->scope[0]->type->name->components())) {
+        return new InvokeExpression(
+          new InstanceExpression(new Variable($generic), new Literal('isInstance')),
+          [$node->expression]
+        );
+      }
+
+      return $node;
+    });
+
     $emitter->transform('class', function($codegen, $node) {
       if ($node->name instanceof IsGeneric) {
         $values= [];

--- a/src/main/php/lang/ast/syntax/php/Generics.class.php
+++ b/src/main/php/lang/ast/syntax/php/Generics.class.php
@@ -262,6 +262,22 @@ class Generics implements Extension {
       return $node;
     });
 
+    $emitter->transform('scope', function($codegen, $node) {
+
+      // Rewrite `T::class` to `$T->literal()` if T is a component
+      if (
+        $node->member instanceof Literal &&
+        'class' === $node->member->expression &&
+        $generic= self::generic(new IsValue($node->type), $codegen->scope[0]->type->name->components())
+      ) {
+        return new InvokeExpression(
+          new InstanceExpression(new Variable($generic), new Literal('literal')),
+          []
+        );
+      }
+      return $node;
+    });
+
     $emitter->transform('class', function($codegen, $node) {
       if ($node->name instanceof IsGeneric) {
         $values= [];

--- a/src/main/php/lang/ast/syntax/php/Generics.class.php
+++ b/src/main/php/lang/ast/syntax/php/Generics.class.php
@@ -252,7 +252,10 @@ class Generics implements Extension {
     $emitter->transform('instanceof', function($codegen, $node) {
 
       // Rewrite `... instanceof T` -> `$T->isInstance(...)` if T is a component
-      if ($generic= self::generic(new IsValue($node->type), $codegen->scope[0]->type->name->components())) {
+      if (
+        is_string($node->type) &&
+        $generic= self::generic(new IsValue($node->type), $codegen->scope[0]->type->name->components())
+      ) {
         return new InvokeExpression(
           new InstanceExpression(new Variable($generic), new Literal('isInstance')),
           [$node->expression]
@@ -275,6 +278,7 @@ class Generics implements Extension {
           []
         );
       }
+
       return $node;
     });
 

--- a/src/test/php/lang/ast/syntax/php/unittest/GenericsTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/GenericsTest.class.php
@@ -89,7 +89,7 @@ class GenericsTest extends EmittingTest {
   public function new_component() {
     $t= $this->type('class %T<E> {
       public static function fixture($arg) {
-        return $E->newInstance($arg);
+        return new E($arg);
       }
     }');
     Assert::equals(6100, Reflection::type($t->newGenericType([Primitive::$INT]))

--- a/src/test/php/lang/ast/syntax/php/unittest/GenericsTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/GenericsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\syntax\php\unittest;
 
 use lang\ast\unittest\emit\EmittingTest;
-use lang\{ArrayType, MapType, Primitive, Reflection};
+use lang\{ArrayType, MapType, Primitive, Reflection, XPClass};
 use test\{Assert, Test, Values};
 
 class GenericsTest extends EmittingTest {
@@ -95,6 +95,19 @@ class GenericsTest extends EmittingTest {
     Assert::equals(6100, Reflection::type($t->newGenericType([Primitive::$INT]))
       ->method('fixture')
       ->invoke(null, ['6100'])
+    );
+  }
+
+  #[Test]
+  public function instanceof_component() {
+    $t= $this->type('class %T<E> {
+      public static function fixture($arg) {
+        return $arg instanceof E;
+      }
+    }');
+    Assert::equals(true, Reflection::type($t->newGenericType([new XPClass(self::class)]))
+      ->method('fixture')
+      ->invoke(null, [$this])
     );
   }
 

--- a/src/test/php/lang/ast/syntax/php/unittest/GenericsTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/GenericsTest.class.php
@@ -112,6 +112,19 @@ class GenericsTest extends EmittingTest {
   }
 
   #[Test]
+  public function component_class() {
+    $t= $this->type('class %T<E> {
+      public static function fixture() {
+        return E::class;
+      }
+    }');
+    Assert::equals(self::class, Reflection::type($t->newGenericType([new XPClass(self::class)]))
+      ->method('fixture')
+      ->invoke(null, [])
+    );
+  }
+
+  #[Test]
   public function string_queue() {
     $r= $this->run('class %T<E> {
       private array<E> $elements= [];


### PR DESCRIPTION
* [x] Rewrite `new T(...)` -> `$T->newInstance(...)` if T is a component
* [x] Rewrite `... instanceof T` -> `$T->isInstance(...)` if T is a component
* [x] Rewrite `T::class` to `$T->literal()` if T is a component